### PR TITLE
Add rlock-protected API for the singleton object

### DIFF
--- a/include/mgos_arduino_dallas_temp.h
+++ b/include/mgos_arduino_dallas_temp.h
@@ -32,6 +32,10 @@ extern "C" {
 // Auto-created, config-controlled singleton.  NULL if disabled.
 DallasTemperature *mgos_ds18x_get_global();
 
+// The rlock-protected access to the above.
+DallasTemperature *mgos_ds18x_get_global_locked();
+void mgos_ds18x_put_global_locked();
+
 // Initialize DallasTemperature driver.
 // Return value: handle opaque pointer.
 DallasTemperature *mgos_arduino_dt_create(OneWire *ow);

--- a/src/mgos_arduino_dallas_temp_c.c
+++ b/src/mgos_arduino_dallas_temp_c.c
@@ -1,17 +1,30 @@
 #include <stdbool.h>
 
 #include <mgos_config.h>
+#include <mgos_system.h>
 
 #include <mgos_arduino_dallas_temp.h>
 
+static struct mgos_rlock_type *lock = NULL;
 static DallasTemperature *s_global_mgos_ds18x = NULL;
+
 DallasTemperature *mgos_ds18x_get_global() {
   return s_global_mgos_ds18x;
+}
+
+DallasTemperature *mgos_ds18x_get_global_locked() {
+  if (s_global_mgos_ds18x) mgos_rlock(lock);
+  return s_global_mgos_ds18x;
+}
+
+void mgos_ds18x_put_global_locked() {
+  if (s_global_mgos_ds18x) mgos_runlock(lock);
 }
 
 bool mgos_arduino_dallas_temperature_init(void) {
   int pin = mgos_sys_config_get_ds18x_pin();
   if (pin < 0) return true;
+  lock = mgos_rlock_create();
   s_global_mgos_ds18x = mgos_arduino_dt_create(mgos_arduino_onewire_create(pin));
   mgos_arduino_dt_begin(s_global_mgos_ds18x);
   return true;


### PR DESCRIPTION
Implemented via the mgos_ds18x_{get,put}_global_locked().